### PR TITLE
Stop calendar blinking on DateRangePickerInput focus switch

### DIFF
--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -245,7 +245,7 @@ function DateRangePickerInput({
         </div>
       }
 
-      {isStartDateFocused && children}
+      {children}
 
       <DateInput
         id={endDateId}
@@ -269,7 +269,7 @@ function DateRangePickerInput({
         regular={regular}
       />
 
-      {isEndDateFocused && children}
+      {children}
 
       {showClearDates && (
         <button


### PR DESCRIPTION
Using `isStartDateFocused` and `isEndDateFocused` to conditionally render `children` causes a re-render whenever the focus switches from the start date input to end date input, during which the calendar disappears and reappears.

This pr adopts same approach as dd9d6b27b300dc8e31d89fcd982d525845e9c698 by skipping the focus check and just rendering the children.